### PR TITLE
Suggest using `npm pkg`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Usage:
   dot-json <file> <key-path> --delete    Delete a key by key-path
 
 Options:
-  --indent=<n>      Indent with <n> of white space characters [default: auto] [--json-value]
+  --indent=<n>      Indent with <n> of white space characters [default: auto]
   -d --delete       Delete the key-path
   -j --json-value   Parse the input value as a JSON string (to set whole objects or arrays)
   -h --help         Show this message with options

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Options:
 
 ### Quick tip for editing package.json
 
-npm 7+ has a [`pkg` command](https://docs.npmjs.com/cli/commands/npm-pkg) that does the same thing without having to use dot-json:
+If you want to change package.json, you can use npm’s [`pkg` command](https://docs.npmjs.com/cli/commands/npm-pkg) instead of `dot-json`:
 
 ```bash
 npm pkg get scripts.test

--- a/README.md
+++ b/README.md
@@ -54,13 +54,12 @@ Options:
 ```
 
 ### Quick tip for editing package.json
-Add to .bash_profile:
+
+npm 7+ has a [`pkg` command](https://docs.npmjs.com/cli/commands/npm-pkg) that does the same thing without having to use dot-json:
+
 ```bash
-alias package="dot-json package.json"
-```
-Use it like this:
-```bash
-package name "my-package"
+npm pkg get scripts.test
+npm pkg set name=my-new-package
 ```
 
 ### Use it in NodeJS


### PR DESCRIPTION
Since `dot-json` is ["done"](https://github.com/maikelvl/dot-json/issues/16#issuecomment-1484117492:~:text=this%20package%20is%20not%20maintained%20that%20well), I think it makes sense to point users to the new `npm-pkg` command that can be used without dependencies.

`dot-json` is still great for editing other json files though 👍 